### PR TITLE
API Permissions rework

### DIFF
--- a/common/authentication/__init__.py
+++ b/common/authentication/__init__.py
@@ -27,7 +27,7 @@ async def is_authenticated(
             token,
             signing_key.key,
             algorithms=["RS256"],
-            audience="https://apply.wafflehacks.tech",
+            audience="https://apply.wafflehacks.org",
             issuer=SETTINGS.api.issuer_url,
         )
     except ExpiredSignatureError:

--- a/common/permissions.py
+++ b/common/permissions.py
@@ -12,54 +12,13 @@ class Permission(Enum):
     The different permissions that can be assigned to a user
     """
 
-    # Create a new application for the current user
-    ApplicationsCreate = "applications:create"
-    # View all applications in the database
-    ApplicationsRead = "applications:read"
-    # View any applications that allowed sponsors to view their information
-    ApplicationsReadPublic = "applications:read:public"
-    # View the application for the current user
-    ApplicationsReadSelf = "applications:read:self"
-    # Edit all applications in the database
-    ApplicationsEdit = "applications:edit"
-    # Edit the application for the current user
-    ApplicationsEditSelf = "applications:edit:self"
-    # Export applications to a CSV
-    ApplicationsExport = "applications:export"
-    # Change the acceptance status of an application
-    ApplicationsStatus = "applications:status"
-    # Manage the legal agreements participants must agree to
-    LegalAgreementsEdit = "legal_agreements:edit"
-    # Manage the known schools in the database
-    SchoolsEdit = "schools:edit"
-    # View all drafted and queued communications
-    CommunicationsRead = "communications:read"
-    # Create, update, and delete communications
-    CommunicationsEdit = "communications:edit"
-    # Send a drafted communication
-    CommunicationsSend = "communications:send"
-    # Manage communication groups
-    CommunicationsGroups = "communications:groups"
-    # View all event statistics
-    EventStatistics = "event:statistics"
-    # View details about the event
-    EventDetailsRead = "event:details:read"
-    # Modify details about the event
-    EventDetailsEdit = "event:details:edit"
-    # Modify integrations such as webhooks and API access
-    IntegrationsEdit = "integrations:edit"
-    # View information about the integrations
-    IntegrationsView = "integrations:view"
-    # View details about the workshops
-    WorkshopsRead = "workshops:read"
-    # Edit and create new workshops
-    WorkshopsEdit = "workshops:edit"
-    # Mark the attendance/feedback status for the current user
-    WorkshopsAttendance = "workshops:attendance"
-    # View the current user's swag status
-    WorkshopsSwagRead = "workshops:swag:read"
-    # Manage the swag tiers
-    WorkshopsSwagManage = "workshops:swag:manage"
+    # The three primary groups that a user can be in
+    Participant = "participant"
+    Sponsor = "sponsor"
+    Organizer = "organizer"
+
+    # A flag extending the permissions of an organizer
+    Director = "director"
 
     def matches(self, value: str) -> bool:
         """

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,6 +18,7 @@
     "react-dropzone": "^12.0.5",
     "react-flatpickr": "^3.10.11",
     "react-google-autocomplete": "^2.6.1",
+    "react-hot-toast": "^2.2.0",
     "react-redux": "^7.2.8",
     "react-router-dom": "^6.3.0",
     "react-scripts": "5.0.0",

--- a/frontend/src/components/Authentication.tsx
+++ b/frontend/src/components/Authentication.tsx
@@ -28,7 +28,7 @@ const Authentication = ({ children }: Props): JSX.Element => {
       else if (!isAuthenticated) await loginWithRedirect();
 
       // Get tokens for the application portal and profile services
-      getAccessTokenSilently({ audience: 'https://apply.wafflehacks.tech' }).then((token) =>
+      getAccessTokenSilently({ audience: 'https://apply.wafflehacks.org' }).then((token) =>
         dispatch(setPortalToken(token)),
       );
       getAccessTokenSilently({ audience: 'https://id.wafflehacks.org' }).then((token) =>

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -24,7 +24,7 @@ ReactDOM.render(
         clientId={AUTH0_CLIENT_ID}
         redirectUri={window.location.origin}
         cacheLocation="localstorage"
-        audience="https://apply.wafflehacks.tech"
+        audience="https://apply.wafflehacks.org"
         useRefreshTokens
       >
         <BrowserRouter>

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -1,6 +1,7 @@
 import { Auth0Provider } from '@auth0/auth0-react';
 import React from 'react';
 import ReactDOM from 'react-dom';
+import { Toaster } from 'react-hot-toast';
 import { Provider } from 'react-redux';
 import { BrowserRouter, Route, Routes } from 'react-router-dom';
 
@@ -28,6 +29,7 @@ ReactDOM.render(
         useRefreshTokens
       >
         <BrowserRouter>
+          <Toaster position="top-right" toastOptions={{ duration: 2500 }} />
           <Authentication>
             <Routes>
               <Route index element={<Status />} />

--- a/frontend/src/pages/application/Application.tsx
+++ b/frontend/src/pages/application/Application.tsx
@@ -1,6 +1,7 @@
 import { useAuth0 } from '@auth0/auth0-react';
 import { RefreshIcon } from '@heroicons/react/outline';
 import React, { useEffect, useState } from 'react';
+import { toast } from 'react-hot-toast';
 import { useNavigate } from 'react-router-dom';
 
 import Card from '../../components/Card';
@@ -36,7 +37,7 @@ const Application = (): JSX.Element => {
 
   // Creation hooks
   const [resume, setResume] = useState<File>();
-  const [createApplication, { isLoading: isCreating, isUninitialized, isError, data: createData }] =
+  const [createApplication, { isLoading: isCreating, isUninitialized, isError, data: createData, reset }] =
     useCreateApplicationMutation();
 
   // Prevent the user from submitting another application
@@ -61,8 +62,14 @@ const Application = (): JSX.Element => {
           body.append('X-AMZ-Algorithm', 'AWS4-HMAC-SHA256');
           body.append('file', resume);
 
-          // TODO: handle errors
-          await fetch(createData.upload.url, { method: 'POST', body });
+          try {
+            await fetch(createData.upload.url, { method: 'POST', body });
+          } catch (e) {
+            toast.error('Failed to upload your resume. Please try again later');
+            console.error(e);
+            reset();
+            return;
+          }
         }
 
         // Ensure we properly navigate to the success page

--- a/frontend/src/pages/application/Application.tsx
+++ b/frontend/src/pages/application/Application.tsx
@@ -73,6 +73,7 @@ const Application = (): JSX.Element => {
         }
 
         // Ensure we properly navigate to the success page
+        toast.success('Your application was submitted!');
         setTimeout(() => navigate('/'), 50);
       }
     })();

--- a/frontend/src/store/errors.ts
+++ b/frontend/src/store/errors.ts
@@ -1,0 +1,19 @@
+import { Middleware, isRejectedWithValue } from '@reduxjs/toolkit';
+import { toast } from 'react-hot-toast';
+
+const capitalize = (s: string) => s.charAt(0).toUpperCase() + s.slice(1);
+
+const errorLogger: Middleware = () => (next) => (action) => {
+  // Handle RTK query errors
+  if (isRejectedWithValue(action) && action.payload.status !== 404) {
+    const status = action.payload.status;
+
+    if (status === 401 || status === 403) toast('Invalid token. Please try logging out and back in.');
+    else if (action.payload.data.reason) toast(capitalize(action.payload.data.reason));
+    else toast('An unexpected error occurred, please try again later');
+  }
+
+  return next(action);
+};
+
+export default errorLogger;

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -2,6 +2,7 @@ import { configureStore } from '@reduxjs/toolkit';
 import { setupListeners } from '@reduxjs/toolkit/query';
 
 import authenticationReducer from './authentication';
+import errorLogger from './errors';
 import profileApi from './profile';
 import registrationApi from './registration';
 
@@ -12,7 +13,7 @@ export const store = configureStore({
     [registrationApi.reducerPath]: registrationApi.reducer,
   },
   middleware: (getDefaultMiddleware) =>
-    getDefaultMiddleware().concat(profileApi.middleware).concat(registrationApi.middleware),
+    getDefaultMiddleware().concat(profileApi.middleware).concat(registrationApi.middleware).concat(errorLogger),
 });
 
 // Trigger re-fetches upon reconnection and upon regaining focus

--- a/frontend/src/store/registration.ts
+++ b/frontend/src/store/registration.ts
@@ -12,7 +12,7 @@ enum Tag {
   Application = 'application',
 }
 
-type ApplicationCreate = Omit<Application, 'participant_id' | 'school' | 'status'> & {
+type ApplicationCreate = Omit<Application, 'participant_id' | 'resume' | 'school' | 'status'> & {
   resume: boolean;
   school: string;
 };

--- a/frontend/src/store/scopes.ts
+++ b/frontend/src/store/scopes.ts
@@ -1,52 +1,11 @@
 export enum PortalScope {
-  // Create a new application for the current user
-  ApplicationsCreate = 'applications:create',
-  // View all applications in the database
-  ApplicationsRead = 'applications:read',
-  // View any applications that allowed sponsors to view their information
-  ApplicationsReadPublic = 'applications:read:public',
-  // View the application for the current user
-  ApplicationsReadSelf = 'applications:read:self',
-  // Edit all applications in the database
-  ApplicationsEdit = 'applications:edit',
-  // Edit the application for the current user
-  ApplicationsEditSelf = 'applications:edit:self',
-  // Export applications to a CSV
-  ApplicationsExport = 'applications:export',
-  // Change the acceptance status of an application
-  ApplicationsStatus = 'applications:status',
-  // Manage the legal agreements participants must agree to
-  LegalAgreementsEdit = 'legal_agreements:edit',
-  // Manage the known schools in the database
-  SchoolsEdit = 'schools:edit',
-  // View all drafted and queued communications
-  CommunicationsRead = 'communications:read',
-  // Create, update, and delete communications
-  CommunicationsEdit = 'communications:edit',
-  // Send a drafted communication
-  CommunicationsSend = 'communications:send',
-  // Manage communication groups
-  CommunicationsGroups = 'communications:groups',
-  // View all event statistics
-  EventStatistics = 'event:statistics',
-  // View details about the event
-  EventDetailsRead = 'event:details:read',
-  // Modify details about the event
-  EventDetailsEdit = 'event:details:edit',
-  // Modify integrations such as webhooks and API access
-  IntegrationsEdit = 'integrations:edit',
-  // View information about the integrations
-  IntegrationsView = 'integrations:view',
-  // View details about the workshops
-  WorkshopsRead = 'workshops:read',
-  // Edit and create new workshops
-  WorkshopsEdit = 'workshops:edit',
-  // Mark the attendance/feedback status for the current user
-  WorkshopsAttendance = 'workshops:attendance',
-  // View the current user's swag status
-  WorkshopsSwagRead = 'workshops:swag:read',
-  // Manage the swag tiers
-  WorkshopsSwagManage = 'workshops:swag:manage',
+  // The three primary groups that a user can be in
+  Participant = 'participant',
+  Sponsor = 'sponsor',
+  Organizer = 'organizer',
+
+  // A flag extending the permissions of an organizer
+  Director = 'director',
 }
 
 export enum ProfileScope {

--- a/frontend/src/store/types.ts
+++ b/frontend/src/store/types.ts
@@ -53,7 +53,7 @@ export interface Application {
   country: string;
   shipping_address: string;
 
-  // TODO: figure out resume
+  resume?: string;
   share_information: boolean;
 
   legal_agreements_acknowledged: boolean;

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -4621,6 +4621,11 @@ globby@^11.0.1, globby@^11.0.4:
     merge2 "^1.4.1"
     slash "^3.0.0"
 
+goober@^2.1.1:
+  version "2.1.9"
+  resolved "https://registry.yarnpkg.com/goober/-/goober-2.1.9.tgz#0faee08fab1a5d55b23e9ec043bb5a1b46fa025a"
+  integrity sha512-PAtnJbrWtHbfpJUIveG5PJIB6Mc9Kd0gimu9wZwPyA+wQUSeOeA4x4Ug16lyaaUUKZ/G6QEH1xunKOuXP1F4Vw==
+
 graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.4, graceful-fs@^4.2.6, graceful-fs@^4.2.9:
   version "4.2.10"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.10.tgz#147d3a006da4ca3ce14728c7aefc287c367d7a6c"
@@ -7288,6 +7293,13 @@ react-google-autocomplete@^2.6.1:
   dependencies:
     lodash.debounce "^4.0.8"
     prop-types "^15.5.0"
+
+react-hot-toast@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/react-hot-toast/-/react-hot-toast-2.2.0.tgz#ab6f4caed4214b9534f94bb8cfaaf21b051e62b9"
+  integrity sha512-248rXw13uhf/6TNDVzagX+y7R8J183rp7MwUMNkcrBRyHj/jWOggfXTGlM8zAOuh701WyVW+eUaWG2LeSufX9g==
+  dependencies:
+    goober "^2.1.1"
 
 react-is@^16.13.1, react-is@^16.7.0:
   version "16.13.1"

--- a/infrastructure/package.json
+++ b/infrastructure/package.json
@@ -33,6 +33,7 @@
     "typescript": "^4.6.3"
   },
   "dependencies": {
+    "@pulumi/auth0": "^2.8.0",
     "@pulumi/aws": "^5.3.0",
     "@pulumi/pulumi": "^3.30.0"
   }

--- a/infrastructure/src/authentication.ts
+++ b/infrastructure/src/authentication.ts
@@ -1,0 +1,95 @@
+import { Client, ResourceServer } from '@pulumi/auth0';
+import { ComponentResource, CustomResourceOptions, Input, Output, ResourceOptions, interpolate } from '@pulumi/pulumi';
+
+interface Args {
+  // The domain where the application portal should be accessible
+  domain: Input<string>;
+}
+
+class Authentication extends ComponentResource {
+  public readonly clientId: Output<string>;
+
+  public readonly api: Output<string>;
+
+  constructor(name: string, args: Args, opts?: CustomResourceOptions) {
+    super('wafflehacks:application-portal:Authentication', name, { options: opts }, opts);
+
+    const defaultResourceOptions: ResourceOptions = { parent: this };
+    const { domain } = args;
+
+    const api = new ResourceServer(
+      `${name}-api`,
+      {
+        allowOfflineAccess: true,
+        name: 'Application Portal',
+        identifier: 'https://apply.wafflehacks.org',
+        signingAlg: 'RS256',
+        skipConsentForVerifiableFirstPartyClients: true,
+
+        // Define the possible permissions
+        scopes: [
+          {
+            description: 'Denotes the participants group',
+            value: 'participant',
+          },
+          {
+            description: 'Denotes the sponsors group',
+            value: 'sponsor',
+          },
+          {
+            description: 'Denotes the organizers group',
+            value: 'organizer',
+          },
+          {
+            description: 'Denotes the directors flag for organizers',
+            value: 'director',
+          },
+        ],
+
+        // Enable RBAC
+        enforcePolicies: true,
+        tokenDialect: 'access_token_authz',
+      },
+      defaultResourceOptions,
+    );
+    this.api = api.identifier as Output<string>; // We know this will be defined
+
+    const urls = ['https://localhost:3000', 'https://localhost.localdomain:3000', interpolate`https://${domain}`];
+    const client = new Client(
+      `${name}-client`,
+      {
+        name: 'Application Portal',
+        appType: 'spa',
+        isFirstParty: true,
+        tokenEndpointAuthMethod: 'none',
+        grantTypes: ['implicit', 'authorization_code', 'refresh_token'],
+        jwtConfiguration: {
+          alg: 'RS256',
+          lifetimeInSeconds: 36000,
+          secretEncoded: false,
+        },
+        oidcConformant: true,
+        refreshToken: {
+          expirationType: 'expiring',
+          leeway: 0,
+          tokenLifetime: 2592000,
+          idleTokenLifetime: 1296000,
+          infiniteTokenLifetime: false,
+          infiniteIdleTokenLifetime: false,
+          rotationType: 'rotating',
+        },
+
+        // Where the application be used
+        callbacks: urls,
+        allowedLogoutUrls: urls,
+        webOrigins: urls,
+      },
+      defaultResourceOptions,
+    );
+
+    this.clientId = client.clientId;
+    this.registerOutputs();
+  }
+}
+
+export default Authentication;

--- a/infrastructure/yarn.lock
+++ b/infrastructure/yarn.lock
@@ -117,6 +117,13 @@
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
   integrity sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA=
 
+"@pulumi/auth0@^2.8.0":
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/@pulumi/auth0/-/auth0-2.8.0.tgz#e2be4a985ab38576f2ad46316e85e2ef647a090e"
+  integrity sha512-cDWRRzGM+BY8FuQZBFWdV+8ewPI78+2o17szZdokhQ2u3N3oEz6P6CwhQ9Mlo1E43TFzVAvl69Win5+ekjN2qw==
+  dependencies:
+    "@pulumi/pulumi" "^3.0.0"
+
 "@pulumi/aws@^5.3.0":
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/@pulumi/aws/-/aws-5.3.0.tgz#2cff1bfc50dffdb91f711c1b9f6c20cfd38d4e54"

--- a/registration/participants.py
+++ b/registration/participants.py
@@ -16,7 +16,7 @@ router = APIRouter()
     "/",
     response_model=List[ParticipantRead],
     name="List Participants",
-    dependencies=[Depends(requires_permission(Permission.ApplicationsRead))],
+    dependencies=[Depends(requires_permission(Permission.Organizer))],
 )
 async def list(db: AsyncSession = Depends(with_db)):
     """
@@ -32,7 +32,7 @@ async def list(db: AsyncSession = Depends(with_db)):
     "/{id}",
     response_model=ParticipantRead,
     name="Read participant",
-    dependencies=[Depends(requires_permission(Permission.ApplicationsRead))],
+    dependencies=[Depends(requires_permission(Permission.Organizer))],
 )
 async def read(id: str, db: AsyncSession = Depends(with_db)):
     """
@@ -49,7 +49,7 @@ async def read(id: str, db: AsyncSession = Depends(with_db)):
     "/{id}",
     status_code=HTTPStatus.NO_CONTENT,
     name="Delete participant",
-    dependencies=[Depends(requires_permission(Permission.ApplicationsEdit))],
+    dependencies=[Depends(requires_permission(Permission.Director))],
 )
 async def remove(id: str, db: AsyncSession = Depends(with_db)):
     """

--- a/registration/schools.py
+++ b/registration/schools.py
@@ -33,7 +33,7 @@ async def list(db: AsyncSession = Depends(with_db)):
     response_model=SchoolRead,
     status_code=HTTPStatus.CREATED,
     name="Create school",
-    dependencies=[Depends(requires_permission(Permission.SchoolsEdit))],
+    dependencies=[Depends(requires_permission(Permission.Organizer))],
 )
 async def create(values: SchoolCreate, db: AsyncSession = Depends(with_db)):
     """
@@ -49,7 +49,7 @@ async def create(values: SchoolCreate, db: AsyncSession = Depends(with_db)):
 @router.patch(
     "/{id}",
     name="Update school",
-    dependencies=[Depends(requires_permission(Permission.SchoolsEdit))],
+    dependencies=[Depends(requires_permission(Permission.Organizer))],
 )
 async def update(
     id: int,
@@ -84,7 +84,7 @@ async def update(
     "/{id}",
     status_code=HTTPStatus.NO_CONTENT,
     name="Delete school",
-    dependencies=[Depends(requires_permission(Permission.SchoolsEdit))],
+    dependencies=[Depends(requires_permission(Permission.Organizer))],
 )
 async def delete(id: int, db: AsyncSession = Depends(with_db)):
     """


### PR DESCRIPTION
This consolidates and simplifies the various permissions from ~20 separate attributes to 3 groups and a flag. This reduces the size of the JWT and cognitive complexity of determining what routes need which permissions. Furthermore, it also makes it easy to change pages shown to the user based on their permission level.

Some basic error handling for queries and uploads was also added using [react-hot-toast](https://react-hot-toast.com/).