### PR TITLE
Fix schools search

### DIFF
--- a/frontend/src/organizers/pages/schools/List.tsx
+++ b/frontend/src/organizers/pages/schools/List.tsx
@@ -1,10 +1,11 @@
-import { PlusIcon, SearchIcon } from '@heroicons/react/outline';
-import React, { useState } from 'react';
+import { PlusIcon } from '@heroicons/react/outline';
+import React from 'react';
 
 import { LinkButton } from '../../../components/buttons';
 import Link from '../../../components/Link';
 import { SchoolList, useListSchoolsQuery } from '../../../store';
 import { EmptyRow, LoadingRow, Pagination, Table, usePagination } from '../../components/table';
+import Search from './Search';
 
 const Row = (school: SchoolList): JSX.Element => (
   <tr>
@@ -19,11 +20,8 @@ const Row = (school: SchoolList): JSX.Element => (
 );
 
 const List = (): JSX.Element => {
-  const [search, setSearch] = useState('');
   const { data = [], isLoading } = useListSchoolsQuery();
-
-  const filtered = data.filter((s) => s.name.toLowerCase().startsWith(search));
-  const { paginated, ...paginationProps } = usePagination(filtered);
+  const { paginated, ...paginationProps } = usePagination(data);
 
   return (
     <>
@@ -34,25 +32,7 @@ const List = (): JSX.Element => {
       </div>
 
       <div className="mt-5 grid grid-cols-1 sm:grid-cols-2">
-        {/* TODO: implement search using Algolia */}
-        <div className="max-w-md">
-          <label htmlFor="search" className="block text-sm font-medium text-gray-700">
-            Search
-          </label>
-          <div className="mt-1 relative rounded-md shadow-sm">
-            <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
-              <SearchIcon className="h-5 w-5 text-gray-400" aria-hidden="true" />
-            </div>
-            <input
-              type="text"
-              name="search"
-              id="search"
-              value={search}
-              onChange={(e) => setSearch(e.target.value)}
-              className="focus:ring-indigo-500 focus:border-indigo-500 block w-full pl-10 sm:text-sm border-gray-300 rounded-md"
-            />
-          </div>
-        </div>
+        <Search />
 
         <div className="mt-5 max-h-10 flex justify-end">
           <LinkButton size="sm" to="/schools/new">

--- a/frontend/src/organizers/pages/schools/List.tsx
+++ b/frontend/src/organizers/pages/schools/List.tsx
@@ -3,12 +3,13 @@ import React, { useState } from 'react';
 
 import { LinkButton } from '../../../components/buttons';
 import Link from '../../../components/Link';
-import { School, useListSchoolsQuery } from '../../../store';
+import { SchoolList, useListSchoolsQuery } from '../../../store';
 import { EmptyRow, LoadingRow, Pagination, Table, usePagination } from '../../components/table';
 
-const Row = (school: School): JSX.Element => (
+const Row = (school: SchoolList): JSX.Element => (
   <tr>
     <Table.Data index>{school.name}</Table.Data>
+    <Table.Data>{school.count}</Table.Data>
     <Table.Data className="relative text-right sm:pr-6">
       <Link to={`/schools/${school.id}`} className="text-indigo-600 hover:text-indigo-900">
         Details
@@ -64,6 +65,7 @@ const List = (): JSX.Element => {
       <Table>
         <Table.Head>
           <Table.Label index>Name</Table.Label>
+          <Table.Label>Applications</Table.Label>
           <Table.InvisibleLabel>View</Table.InvisibleLabel>
         </Table.Head>
         <Table.Body>

--- a/frontend/src/organizers/pages/schools/Search.tsx
+++ b/frontend/src/organizers/pages/schools/Search.tsx
@@ -1,0 +1,89 @@
+import { Combobox } from '@headlessui/react';
+import { SearchIcon, SelectorIcon } from '@heroicons/react/outline';
+import algoliasearch from 'algoliasearch/lite';
+import classNames from 'classnames';
+import React, { useEffect, useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+const APP_ID = process.env.REACT_APP_ALGOLIA_APP_ID || '';
+const API_KEY = process.env.REACT_APP_ALGOLIA_API_KEY || '';
+
+interface SearchItem {
+  objectID: string;
+  name: string;
+}
+
+const Search = (): JSX.Element => {
+  const navigate = useNavigate();
+
+  const [query, setQuery] = useState('');
+  const [options, setOptions] = useState<SearchItem[]>([]);
+
+  const client = useMemo(() => algoliasearch(APP_ID, API_KEY), [APP_ID, API_KEY]);
+
+  useEffect(() => {
+    const timeout = setTimeout(async () => {
+      if (query.length === 0) {
+        setOptions([]);
+        return;
+      }
+
+      const responses = await client.search<SearchItem>([
+        {
+          type: 'default',
+          indexName: 'schools',
+          query,
+          params: {
+            hitsPerPage: 10,
+          },
+        },
+      ]);
+
+      const { hits } = responses.results[0];
+      setOptions(hits);
+    }, 250);
+
+    return () => clearTimeout(timeout);
+  }, [client, query]);
+
+  return (
+    <Combobox as="div" value="" onChange={(id: string) => navigate(`/schools/${id}`)} className="max-w-md">
+      <Combobox.Label className="block text-sm font-medium text-gray-700">Search</Combobox.Label>
+      <div className="relative mt-1 rounded-md shadow-sm">
+        <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+          <SearchIcon className="h-5 w-5 text-gray-400" aria-hidden="true" />
+        </div>
+        <Combobox.Input
+          className="focus:ring-indigo-500 focus:border-indigo-500 block w-full pl-10 sm:text-sm border-gray-300 rounded-md"
+          onChange={(e) => setQuery(e.target.value)}
+          displayValue={(v: string) => v}
+          autoComplete="off"
+        />
+        <Combobox.Button className="absolute inset-y-0 right-0 flex items-center rounded-r-md px-2 focus:outline-none">
+          <SelectorIcon className="h-5 w-5 text-gray-400" aria-hidden="true" />
+        </Combobox.Button>
+
+        {options.length > 0 && (
+          <Combobox.Options className="absolute z-10 mt-1 max-h-60 w-full overflow-auto rounded-md bg-white py-1 text-base shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none sm:text-sm">
+            {options.map((o) => (
+              <Combobox.Option
+                key={o.objectID}
+                value={o.objectID}
+                className={({ active }) =>
+                  classNames(
+                    'relative cursor-default select-none py-2 pl-3 pr-9',
+                    active ? 'bg-indigo-600 text-white' : 'text-gray-900',
+                  )
+                }
+              >
+                <span className="block truncate">{o.name}</span>
+              </Combobox.Option>
+            ))}
+          </Combobox.Options>
+        )}
+      </div>
+    </Combobox>
+  );
+};
+
+export default Search;

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -69,6 +69,7 @@ export type {
   ReducedApplication,
   ReducedMessage,
   School,
+  SchoolList,
   ParticipantWithSwag,
   ReducedSwagTier,
   SwagTier,

--- a/frontend/src/store/registration.ts
+++ b/frontend/src/store/registration.ts
@@ -36,6 +36,10 @@ interface ApplicationStatus {
   status: Status;
 }
 
+interface SchoolList extends School {
+  count: number;
+}
+
 interface SchoolDetail extends School {
   applications: ReducedApplication[];
 }
@@ -133,9 +137,9 @@ const api = createApi({
     }),
 
     // School endpoints
-    listSchools: builder.query<School[], void>({
+    listSchools: builder.query<SchoolList[], void>({
       query: () => '/registration/schools/',
-      providesTags: (result: School[] = []) => [Tag.School, ...result.map((s) => ({ type: Tag.School, id: s.id }))],
+      providesTags: (result: SchoolList[] = []) => [Tag.School, ...result.map((s) => ({ type: Tag.School, id: s.id }))],
     }),
     getSchool: builder.query<SchoolDetail, string>({
       query: (id) => `/registration/schools/${id}`,

--- a/frontend/src/store/types.ts
+++ b/frontend/src/store/types.ts
@@ -44,6 +44,10 @@ export interface School {
   name: string;
 }
 
+export interface SchoolList extends School {
+  count: number;
+}
+
 export interface ReducedApplication {
   participant: Participant;
 


### PR DESCRIPTION
This makes the schools search in the organizer view more user-friendly by using Algolia instead of a dumb prefix search. In addition, the list of schools itself is now sortable and has a column showing the total number of applications. The default sort order is descending by the total number of applications.