### PR TITLE
Add initial database sync

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,12 @@ REGISTRATION_ALGOLIA_API_KEY=1234567890abcdeffedcba0987654321
 # The S3 bucket for storing resumes
 REGISTRATION_BUCKET=some-s3-bucket-name
 
+# Disables the full database synchronization on service startup
+SYNC_DISABLE_INITIAL_PULL=true
+
+# The profiles service API to use for the initial sync
+SYNC_PROFILES_API=https://api.id.wafflehacks.org
+
 # The SQS queue for synchronizing the participant info
 SYNC_QUEUE=https://sqs.region.amazonaws.com/account/queue
 

--- a/common/settings/specific.py
+++ b/common/settings/specific.py
@@ -34,6 +34,12 @@ class RegistrationSettings(BaseAPI):
 
 
 class SyncSettings(BaseModel):
+    # Disables the full database sync on service startup
+    disable_initial_pull: bool = False
+
+    # The profiles service API to use for the initial sync
+    profiles_api: HttpUrl = HttpUrl(url="https://api.id.wafflehacks.org")
+
     # The SQS queue for synchronizing the participant info
     queue: HttpUrl
 

--- a/common/settings/specific.py
+++ b/common/settings/specific.py
@@ -38,7 +38,9 @@ class SyncSettings(BaseModel):
     disable_initial_pull: bool = False
 
     # The profiles service API to use for the initial sync
-    profiles_api: HttpUrl = HttpUrl(url="https://api.id.wafflehacks.org")
+    profiles_api: HttpUrl = HttpUrl(
+        url="https://api.id.wafflehacks.org", scheme="https"
+    )
 
     # The SQS queue for synchronizing the participant info
     queue: HttpUrl

--- a/poetry.lock
+++ b/poetry.lock
@@ -171,6 +171,17 @@ tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)"
 tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "cloudpickle"]
 
 [[package]]
+name = "aws-requests-auth"
+version = "0.4.3"
+description = "AWS signature version 4 signing process for the python requests module"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+requests = ">=0.14.0"
+
+[[package]]
 name = "backcall"
 version = "0.2.0"
 description = "Specifications for callback functions passed in to an API"
@@ -1854,7 +1865,7 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "27044340e3e2a1a23d3d69d0fc2edf9f7cf7a451c452a9c93f002a6379b7937b"
+content-hash = "650443776d924fc2f3a4270779d3293ad80be4eb563f4590f695d3855339f365"
 
 [metadata.files]
 aiodns = [
@@ -2002,6 +2013,10 @@ asyncpg = [
 attrs = [
     {file = "attrs-21.4.0-py2.py3-none-any.whl", hash = "sha256:2d27e3784d7a565d36ab851fe94887c5eccd6a463168875832a1be79c82828b4"},
     {file = "attrs-21.4.0.tar.gz", hash = "sha256:626ba8234211db98e869df76230a137c4c40a12d72445c45d5f5b716f076e2fd"},
+]
+aws-requests-auth = [
+    {file = "aws-requests-auth-0.4.3.tar.gz", hash = "sha256:33593372018b960a31dbbe236f89421678b885c35f0b6a7abfae35bb77e069b2"},
+    {file = "aws_requests_auth-0.4.3-py2.py3-none-any.whl", hash = "sha256:646bc37d62140ea1c709d20148f5d43197e6bd2d63909eb36fa4bb2345759977"},
 ]
 backcall = [
     {file = "backcall-0.2.0-py2.py3-none-any.whl", hash = "sha256:fbbce6a29f263178a1f7915c1940bde0ec2b2a967566fe1c65c1dfb7422bd255"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ protobuf = "3.20.1"
 nanoid = "^2.0.0"
 pytz = "^2022.1"
 nats-py = "^2.1.3"
+aws-requests-auth = "^0.4.3"
 
 [tool.poetry.dev-dependencies]
 black = "^22.3.0"

--- a/sync/initial.py
+++ b/sync/initial.py
@@ -1,0 +1,87 @@
+import logging
+from collections import namedtuple
+from typing import Dict, List
+from urllib.parse import urljoin, urlparse
+
+from aiohttp import ClientSession
+from aws_requests_auth.boto_utils import BotoAWSRequestsAuth
+from boto3.session import Session
+from pydantic import parse_obj_as
+from sqlalchemy.future import select
+
+from common import SETTINGS
+from common.database import Participant, db_context
+
+from .models import Profile
+
+session = Session()
+credentials = session.get_credentials()
+
+logger = logging.getLogger(__name__)
+
+
+async def sync():
+    """
+    Perform the initial sync of participants on boot
+    """
+    if SETTINGS.sync.disable_initial_pull:
+        logger.info("skipping initial synchronization")
+        return
+
+    async with db_context() as db:
+        result = await db.execute(select(Participant.id))
+        participants = set(result.scalars().all())
+
+        profiles = await fetch_profiles()
+
+        # We don't particularly care if the u
+        if len(participants) >= len(profiles):
+            logger.info("already in sync")
+            return
+
+        logger.info("databases out of sync, fixing...")
+
+        for profile in profiles:
+            if profile.id not in participants:
+                logger.debug(f"adding {profile.id}")
+
+                db.add(Participant.from_orm(profile))
+
+        await db.commit()
+        logger.info("initial sync complete!")
+
+
+async def fetch_profiles() -> List[Profile]:
+    """
+    Get a list of all the known profiles
+    """
+    url = urljoin(SETTINGS.sync.profiles_api, "manage")
+    headers = generate_auth_headers(url)
+
+    async with ClientSession(headers=headers, raise_for_status=True) as client:
+        response = await client.get(url)
+        json = await response.json()
+
+        return parse_obj_as(List[Profile], json)
+
+
+def generate_auth_headers(url: str) -> Dict[str, str]:
+    """
+    Generate AWS signature v4 authorization headers for the given URL
+    """
+    # Create a fake requests.Request
+    Request = namedtuple("Request", ["url", "body", "method"])
+    request = Request(url=url, body=None, method="GET")
+
+    # Initialize the auth
+    parts = urlparse(url)
+    auth = BotoAWSRequestsAuth(parts.hostname, session.region_name, "execute-api")
+
+    # Generate the headers
+    frozen = credentials.get_frozen_credentials()
+    return auth.get_aws_request_headers(
+        request,
+        aws_access_key=frozen.access_key,
+        aws_secret_access_key=frozen.secret_key,
+        aws_token=frozen.token,
+    )


### PR DESCRIPTION
When the sync service first boots, an initial sync will be performed to add any missing records or update any out-of-sync ones. This should prevent the databases from getting too far out of sync if the service goes down for some period of time.