### PR TITLE
Migrate to AWS ECR

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           role-to-assume: ${{ secrets.AWS_ROLE }}
           role-session-name: ${{ github.run_id }}
-          aws-region: us-west-2
+          aws-region: us-east-1
 
       - uses: aws-actions/amazon-ecr-login@v1
         id: login-ecr

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -12,6 +12,7 @@ jobs:
     name: Applications
     runs-on: ubuntu-20.04
     strategy:
+      fail-fast: false
       matrix:
         app:
           - api
@@ -29,23 +30,31 @@ jobs:
             ${{ runner.os }}-buildx-${{ hashFiles('**/poetry.lock') }}-
             ${{ runner.os }}-buildx-
 
-      - uses: docker/setup-buildx-action@v2
-      - uses: docker/login-action@v2
+      - uses: aws-actions/configure-aws-credentials@v2
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          role-to-assume: ${{ secrets.AWS_ROLE }}
+          role-session-name: ${{ github.run_id }}
+          aws-region: us-west-2
+
+      - uses: aws-actions/amazon-ecr-login@v1
+        id: login-ecr
+        with:
+          registry-type: public
+
+      - uses: docker/setup-buildx-action@v2
 
       - uses: docker/metadata-action@v4
         id: meta
         with:
-          images: wafflehacks/application-portal
+          images: ${{ steps.login-ecr.outputs.registry }}/wafflehacks/application-portal-${{ matrix.app }}
           tags: |
-            type=ref,event=branch,prefix=${{ matrix.app }}-
-            type=semver,pattern=${{ matrix.app }}-{{version}}
-            type=semver,pattern=${{ matrix.app }}-{{major}}.{{minor}}
-            type=semver,pattern=${{ matrix.app }}-{{major}}
-            type=sha,prefix=${{ matrix.app }}-
-            type=raw,value=${{ matrix.app }}-latest
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha
+            type=raw,value=latest,enable={{is_default_branch}}
 
       - uses: docker/build-push-action@v4
         with:

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -18,6 +18,9 @@ jobs:
           - api
           - mjml
           - tasks
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
Migrate to AWS ECR for our docker images, following the recent changes with Docker Hub.