### PR TITLE
Automatically apply organizer permissions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,6 +41,9 @@ COOKIE_SECURE=true
 # The S3 bucket for storing resumes
 RESUME_BUCKET=some-s3-bucket-name
 
+# The domain emails must end with to be automatically assigned organizer permissions
+ORGANIZER_EMAIL_DOMAIN=wafflehacks.org
+
 ###########
 ## Tasks ##
 ###########

--- a/api/authentication/profile.py
+++ b/api/authentication/profile.py
@@ -4,11 +4,13 @@ from fastapi import APIRouter, Depends, Response
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.session import Session, with_incomplete_profile, with_user_id
+from api.settings import SETTINGS
 from common.database import (
     Participant,
     ParticipantCreate,
     ParticipantRead,
     ParticipantUpdate,
+    Role,
     with_db,
 )
 from common.tasks import broadcast
@@ -24,6 +26,9 @@ async def complete(
     db: AsyncSession = Depends(with_db),
 ):
     participant = Participant.from_orm(details, {"email": session.email})
+    if participant.email.endswith("@" + SETTINGS.organizer_email_domain):
+        participant.role = Role.Organizer
+
     db.add(participant)
     await db.commit()
 

--- a/api/fly.toml
+++ b/api/fly.toml
@@ -29,6 +29,8 @@ primary_region = "yyz"
   COOKIE_DOMAIN = "wafflehacks.org"
   COOKIE_SECURE = "true"
 
+  ORGANIZER_EMAIL_DOMAIN = "wafflehacks.org"
+
 [[services]]
   internal_port = 8000
   processes = ["app"]

--- a/api/settings.py
+++ b/api/settings.py
@@ -22,5 +22,8 @@ class Settings(BaseSettings):
     cookie_domain: str
     cookie_secure: bool
 
+    # The domain emails must end with to be automatically assigned organizer permissions
+    organizer_email_domain: str
+
 
 SETTINGS = Settings()

--- a/frontend/src/organizers/pages/admin/users/List.tsx
+++ b/frontend/src/organizers/pages/admin/users/List.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 
-import Badge from '../../../../components/Badge';
+import Badge, { Color } from '../../../../components/Badge';
 import Link from '../../../../components/Link';
 import { Participant, useListParticipantsQuery } from '../../../../store';
+import { Role } from '../../../../store/types';
 import { EmptyRow, LoadingRow, Pagination, Table, usePagination } from '../../../components/table';
 
 const Row = (participant: Participant): JSX.Element => (
@@ -11,7 +12,9 @@ const Row = (participant: Participant): JSX.Element => (
       {participant.first_name} {participant.last_name}
     </Table.Data>
     <Table.Data>{participant.email}</Table.Data>
-    <Table.Data>{participant.role}</Table.Data>
+    <Table.Data>
+      <Badge color={roleColor(participant.role)}>{participant.role}</Badge>
+    </Table.Data>
     <Table.Data>
       <Badge color={participant.is_admin ? 'green' : 'red'}>{participant.is_admin ? 'Yes' : 'No'}</Badge>
     </Table.Data>
@@ -22,6 +25,19 @@ const Row = (participant: Participant): JSX.Element => (
     </Table.Data>
   </tr>
 );
+
+const roleColor = (role: Role): Color => {
+  switch (role) {
+    case Role.Participant:
+      return 'gray';
+    case Role.Sponsor:
+      return 'blue';
+    case Role.Organizer:
+      return 'purple';
+    default:
+      throw new Error(`unknown role: ${role}`);
+  }
+};
 
 const List = (): JSX.Element => {
   const { data: users = [], isLoading } = useListParticipantsQuery();


### PR DESCRIPTION
Add `ORGANIZER_EMAIL_DOMAIN` for automatically assigning organizer permissions if the new user's email ends with the given domain. Rather than simply checking if the email ends with the domain, we check that it ends with `@<domain>` to prevent emails like `not-wafflehacks.org` from matching `wafflehacks.org`.