### PR TITLE
Display participant counts on dashboard

### DIFF
--- a/api/statistics/registration.py
+++ b/api/statistics/registration.py
@@ -13,6 +13,19 @@ from common.database import Application, School, with_db
 router = APIRouter()
 
 
+class Counts(BaseModel):
+    accepted: int = 0
+    pending: int = 0
+    rejected: int = 0
+    total: int
+
+
+@router.get("/", response_model=Counts)
+async def status(db: AsyncSession = Depends(with_db)):
+    result = await db.execute(grouped_count("status"))
+    return {row.label.value: row.count for row in result.all()}
+
+
 class StatisticEntry(BaseModel):
     label: str
     count: int

--- a/frontend/src/organizers/pages/dashboard/Dashboard.tsx
+++ b/frontend/src/organizers/pages/dashboard/Dashboard.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import BarChart from './BarChart';
 import ChartContainer from './ChartContainer';
+import ParticipantCounts from './ParticipantCounts';
 import PieChart from './PieChart';
 import RegistrationsPerDay from './RegistrationsPerDay';
 
@@ -16,7 +17,9 @@ const Dashboard = (): JSX.Element => {
         </div>
       </div>
 
-      <RegistrationsPerDay />
+      <ParticipantCounts />
+
+      <RegistrationsPerDay className="mt-8" />
 
       <div className="grid grid-cols-1 lg:grid-cols-2 justify-items-center mt-6 gap-y-8 gap-x-4">
         <ChartContainer title="Gender" source="gender" chart={PieChart} />

--- a/frontend/src/organizers/pages/dashboard/ParticipantCounts.tsx
+++ b/frontend/src/organizers/pages/dashboard/ParticipantCounts.tsx
@@ -1,0 +1,35 @@
+import { ArrowPathIcon, QuestionMarkCircleIcon } from '@heroicons/react/24/outline';
+import React from 'react';
+
+import { useGetParticipantCountsByStatusQuery } from 'store';
+
+import { IconWithLabel } from './ChartContainer';
+
+const ParticipantCounts = (): JSX.Element => {
+  const { data, isLoading } = useGetParticipantCountsByStatusQuery();
+
+  if (isLoading) return <IconWithLabel text="Loading..." icon={ArrowPathIcon} />;
+  else if (data === undefined) return <IconWithLabel text="No data" icon={QuestionMarkCircleIcon} />;
+
+  return (
+    <dl className="mt-5 grid grid-cols-1 gap-5 sm:grid-cols-3">
+      <Count label="Accepted" count={data.accepted} />
+      <Count label="Pending" count={data.pending} />
+      <Count label="Rejected" count={data.rejected} />
+    </dl>
+  );
+};
+
+interface CountProps {
+  label: string;
+  count: number;
+}
+
+const Count = ({ label, count }: CountProps): JSX.Element => (
+  <div className="overflow-hidden rounded-lg bg-white px-4 py-5 shadow sm:p-6">
+    <dt className="truncate text-sm font-medium text-gray-500">{label} participants</dt>
+    <dd className="mt-1 text-3xl font-semibold tracking-tight text-gray-900">{count}</dd>
+  </div>
+);
+
+export default ParticipantCounts;

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -94,6 +94,7 @@ export {
   useGetRegistrationStatisticsQuery,
   useGetPerDayRegistrationStatisticsQuery,
   useGetSchoolStatisticsQuery,
+  useGetParticipantCountsByStatusQuery,
 } from './statistics';
 export type {
   ApplicationAutosave,

--- a/frontend/src/store/statistics.ts
+++ b/frontend/src/store/statistics.ts
@@ -19,6 +19,12 @@ interface PerDayArgs {
   end?: string;
 }
 
+interface Counts {
+  pending: number;
+  accepted: number;
+  rejected: number;
+}
+
 const api = createApi({
   reducerPath: 'statistics',
   baseQuery: fetchBaseQuery({ baseUrl: BASE_URL, credentials: 'include' }),
@@ -36,6 +42,9 @@ const api = createApi({
     getSchoolStatistics: builder.query<SchoolStatisticEntry[], void>({
       query: () => '/statistics/registration/school',
     }),
+    getParticipantCountsByStatus: builder.query<Counts, void>({
+      query: () => '/statistics/registration/',
+    }),
   }),
 });
 
@@ -44,4 +53,5 @@ export const {
   useGetRegistrationStatisticsQuery,
   useGetPerDayRegistrationStatisticsQuery,
   useGetSchoolStatisticsQuery,
+  useGetParticipantCountsByStatusQuery,
 } = api;


### PR DESCRIPTION
Display the participant counts grouped by application status on the dashboard. Implemented using the `grouped_query` method and extracted into an object.